### PR TITLE
Talks collection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     execjs (2.2.2)
     fast-stemmer (1.0.2)
     ffi (1.9.6)
+    ffi (1.9.6-x64-mingw32)
     hitimes (1.2.2)
     jekyll (2.5.3)
       classifier-reborn (~> 2.0)
@@ -65,6 +66,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ sass:
   style: compressed
 paginate: 6
 paginate_path: "archive/page-:num"
+collections:
+  - talks
 
 gems:
   - jekyll-paginate

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+<h2 itemprop="startDate" content="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%B %d, %Y" }}</h2>
+<p>{{ page.time }} @ {{ page.location }}</p>
+
+
+{% capture pagedate %}{{ page.date | date: '%B %-d, %Y'}}{% endcapture %}
+{% assign dateTalks = site.talks | where:"date",pagedate %}
+{% for talk in dateTalks %}
+	<h3 class="talk-title">{{ talk.title}} </h3>
+	<h4 class="talk-speaker">
+		{{ talk.speaker }}
+		{% if talk.twitter %}
+			<small><a href="https://twitter.com/{{ talk.twitter }}">@{{ talk.twitter }}</a></small>
+		{% endif %}
+	</h4>
+
+	{{ talk.content }}
+{% endfor %}

--- a/_posts/2013-05-14-meeting.md
+++ b/_posts/2013-05-14-meeting.md
@@ -1,40 +1,6 @@
 ---
-layout: default
+layout: post
 date: May 14th 2013
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr West Des Moines, IA 50266
----
-
-### Intro Topic * Writing JavaScript like a grown-up
-
-Are you producing write-once / read-never javascript? Do you want to
-develop something you can reason about but just don't know where to start?
-Join us for a 30 minute beginner friendly discussion about how I was writing
-javascript a year ago and what I did to improve the quality of my client side
-code!
-
-[Toran Billups](http://toranbillups.com) is a python and javascript
-enthusiast with hopes of knowing enough about ember.js and django to build a
-modern web app
-
-### Advanced Topic * JavaScript Game Development (intermediate ImpactJS)
-
-Joel will be giving a Part II version of his [DSM Webgeeks lunch presentation](http://www.dsmwebgeeks.com/2013/04/javascript-game-development-%E2%80%93-lunch-meeting-wed-april-17th/)
-(April 17th) on Javascript Game Development and will build on some of the basic
-concepts he demonstrated.  He will be modeling much of the talk after the Introducing
-HTML5 Game Development book by Jesse Freeman and will introduce concepts such as: 
-
-- Gravity / Friction
-- Collision Objects
-- Player vs. Enemy entities
-
-If there is time and interest he will also demonstrate how to package an ImpactJS
-game to run native on an iOS device - while not writing ANY Objective-C.
-
-[Joel](http://joel.io) is a software developer in his almost 30's who enjoys
-football, playing with his son, and writing code.  His first project was a
-fantasy football website that derived it's statistics from nintendo memory
-dumps and currently spends his time developing video games.  So far in 2013
-he has started roughly 5 new games and finished 3.  You can read about his
-video game adventures at [http://joel.io](http://joel.io) and find him on
-twitter [@taddeimania](https://twitter.com/taddeimania)
+---

--- a/_posts/2013-06-13-meeting.md
+++ b/_posts/2013-06-13-meeting.md
@@ -1,34 +1,6 @@
 ---
-layout: default
+layout: post
 date: June 13th 2013
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr West Des Moines, IA 50266
----
-
-### Intro Topic * Chrome dev tools tips and tricks
-
-[Torey Maerz](https://twitter.com/toreym) will start off the meeting
-with a quick 30 minute tips and tricks overview for developing and
-debugging in chrome dev tools. He'll cover some helpful development
-workflow tips to help you work more efficiently, show you how you
-can use the profiler and network tabs to find inefficiencies in your
-code, and even some newer items just added to dev tools.
-
-Torey previously lead a UI dev team at [Principal](http://http://www.principal.com/)
-and was the CIO at [Appcore](http://www.appcore.com/) before starting
-his own software company, C5 Software.
-
-
-### Advanced Topic * Using Backbone to Visualize Music
-
-For this talk, I'm thinking Harder, Better, Faster, Stronger -- using
-Backbone to visualize music. I'll demonstrate how to use routers,
-models, and views to do some cool stuff -- like making a media player
-that can pick up where you left off, visualize the music to which you
-are listening, and manage a music library -- ya know, non-crud stuff.
-
-Hi, I'm Jack Viers and I like solving problems with software. I work
-at [Banno](http://www.banno.com) helping banks provide great experiences
-for their customers. I love discussions, and believe in making software
-for the fun of making software. Say hi [@jackviers](https://twitter.com/jackviers)
-on twitter or [jackcviers@gmail.com](mailto:jackcviers@gmail.com).
+---

--- a/_posts/2013-07-11-meeting.md
+++ b/_posts/2013-07-11-meeting.md
@@ -1,18 +1,6 @@
 ---
-layout: default
+layout: post
 date: July 11th 2013
 time: 6:00 - 7:30 pm
 location: DMACC West Campus 5959 Grand Ave, West Des Moines, IA 50266
----
-
-### Intro Topic * What is "this" ?
-
-Part of JavaScript’s charm and elegance stems from the fact that it works quite a bit differently than most other languages. The “this” keyword is one of the parts of JavaScript that seems to behave perhaps a bit differently than what might be expected. In addition to the “this” keyword, I will discuss execution contexts, the “new” operator, the call, apply and bind functions, and strict mode.
-
-[Matthew J. Morrison](https://twitter.com/mattjmorrison) is a passionate, professional software developer and hobbyist; language nerd and regular user of Unix, Python, Ruby & JavaScript.
-
-### Advanced Topic * Writing tests for javascript with QUnit/Sinon and Karma
-
-So you want to write a single page app with your javascript framework of choice, but how do you test these rich web applications? Join me for a discussion about my frontend testing journey and a hands on demo of QUnit/Sinon and the Karma test runner. Some basic understanding of unit testing is recommended but not required.
-
-[Toran Billups](https://twitter.com/toranb) builds REST services with python/django and rich javascript frontends with ember.js
+---

--- a/_posts/2013-08-20-meeting.md
+++ b/_posts/2013-08-20-meeting.md
@@ -1,16 +1,6 @@
 ---
-layout: default
+layout: post
 date: August 20th 2013
 time: 6:00 - 7:30 pm
 location: Goodsmiths 218 1/2 5th Street West Des Moines, Iowa 50265
----
-
-### Intro Topic * why single page apps anyway?
-
-Ever wonder what all the hype around single page apps is about? Join us for a beginner friendly discussion about what makes building a single page app different from traditional web development and why you would choose one over the other.
-
-### Advanced Topic * a gentle introduction to ember.js
-
-As the ember.js javascript framework matures to 1.0 what does the "hello world" experience look like today? What does each component in the framework do and what are the naming conventions required to wire them up? What is the story behind the new router api and how do you work with nested routes/controllers? What is the persistence story?
-
-[Toran Billups](https://twitter.com/toranb) builds REST services with python/django and rich javascript frontends with ember.js
+---

--- a/_posts/2013-09-10-meeting.md
+++ b/_posts/2013-09-10-meeting.md
@@ -1,24 +1,6 @@
 ---
-layout: default
+layout: post
 date: September 10th 2013
 time: 6:00 - 7:30 pm
 location: Dice 12150 Meredith Drive Urbandale, IA 50323
----
-
-### Intro Topic * github and the open source ecosphere
-
-If you've been attending user group meetings, or just had someone forward you a GitHub URL - you've seen some of the things that developers have been doing in the Open Source community. In this session, I'll talk about open source development, the GitHub ecosphere and how you can get involved. Along the way, we'll share some success stories (and not so successful stories) about getting involved in the community, how you can make positive contributions and what to expect when you start your own open source project.
-
-[Chad Thompson](https://twitter.com/chadothompson) is a DevOps Engineer with Dice Holdings, Inc. in Urbandale. Chad has enjoyed a great career in creating and helping others create great technology as a developer, architect and consultant. Chad has served as organizer of the Central Iowa Java Users Group (CIJUG), is currently a Senior Contributing Editor to the Independent Oracle Users Group (IOUG) SELECT Journal and has enjoyed the pleasure of speaking to a variety of audiences on technology topics. You can follow Chad on Twitter (@chadothompson) or read some of his writings at http://chadthompson.me
-
-### Advanced Topic * Intro to Grunt: Stop doing things manually
-
-Grunt is a Javascript Task Runner. If you've never heard of Grunt then this presentation is for you. Grunt can help you automatically compile Less/Coffeescript, compile templates, aggregate/minify files, and much more . Don't worry though, you don't have to run Grunt every time you want it to do something. I'll show you the Grunt Watch feature, so you can code faster.
-
-[Chuck Rolek](https://twitter.com/crolek) is a front-end infrastructure developer at Principal Financial Group. He enjoys promoting User Experience practices, teaching, and coding.
-
-### Sponsor
-
-Thanks to [Dice](http://www.dice.com) for providing the location, pizza and book give away!
-
-<img src="http://dsmjs.com/assets/images/dice.png" style="height: 60px; width: 109px;"> 
+---

--- a/_posts/2013-10-08-meeting.md
+++ b/_posts/2013-10-08-meeting.md
@@ -1,30 +1,6 @@
 ---
-layout: default
+layout: post
 date: October 8th 2013
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr  West Des Moines, IA 50266
----
-
-### Intro Topic * Working with files in the browser
-
-Reading and manipulating files has traditionally been a job for the server. But with new JavaScript APIs, it opens a world of possibilities to work with files in the browser. Get a quick introduction to the File API, the FileReader object, and see a couple of cool things you can do with them.
-
-[Eric Ponto](https://twitter.com/EricPonto) is a web developer at Principal Financial Group. His life pretty much revolves around the 3 Fs: family, football, and front-end development (not necessarily in that order, depending on the day). You can follow Eric on Twitter @EricPonto (or if you're a big Iowa Football fan, @FightForIowa)
-
-### Advanced Topic * Introduction to ClojureScript
-
-ClojureScript compiles [Clojure](http://clojure.org/) to optimized JavaScript. Specifically, the compiler emits JavaScript compatible with the advanced compilation mode of [Google Closure](http://code.google.com/closure/).
-
-We'll start with an introduction to [Clojure](http://clojure.org/), assuming no prior knowledge of the language. Clojure is a dynamic, general purpose programming language (actually a Lisp dialect) that features a rich set of immutable data structures, lazy sequences, first-class functions, macros, and other features.
-
-Then we'll look at ClojureScript, which compiles Clojure code to optimized JavaScript that can be used on a web page or run in another JavaScript environment such as [Node.js](http://nodejs.org/).
-
-We'll cover
-
-* Setting up a simple ClojureScript project
-* ClojureScript build process, including compilation modes
-* JavaScript Interop
-
-If time permits, we'll look at the new [core.async](https://github.com/clojure/core.async) library that provides a solution to "callback hell."
-
-[David W. Body](https://twitter.com/david_body) is a generalist application developer, president of [Big Creek Software, LLC](http://www.bigcreek.com/), and organizer of the [Iowa Ruby Brigade](http://www.iowaruby.org/).
+---

--- a/_posts/2013-11-12-meeting.md
+++ b/_posts/2013-11-12-meeting.md
@@ -1,34 +1,6 @@
 ---
-layout: default
+layout: post
 date: November 12th 2013
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr  West Des Moines, IA 50266
----
-
-### Intro Topic * Is your Grunt file maintainable?
-
-This lightning talk will present the way that Grunt files used to be written and show a couple of Node modules (load-grunt-config and load-grunt-tasks) that allow your Gruntfile to be minimal. This is the JavaScript (or CoffeeScript) of the future.
-
-[Brandon Williams](https://twitter.com/williamsb86) is a web developer with a passion for TDD. He enjoys writing Python, CoffeeScript, and improving his Vim foo
-
-### Advanced Topic * Writing my first non-trivial single page app
-
-Anyone can hype their favorite javascript framework but what happens when you need to build something bigger than a todo app? I decided to find out for myself a few months back when I started writing my first ambitious javascript application.
-
-During this talk I'll cover
-
-* What is so great about the url?
-* So what happens when I click refresh?
-* Prevent data loss when the user clicks the back button
-* Do you need objects with rich relationships?
-* How to bootstrap your application at runtime
-* Sharing state between views/routes
-* What about catastrophic javascript errors?
-* What does $.ajax error handling look like?
-* Where do you handle application wide navigation?
-* How does jQuery fit into the picture today?
-* What build tool did I use and how did I deploy with it?
-* When did I find unit tests helpful? When integration tests?
-* Transactions -do we need them on the client?
-
-[Toran Billups](https://twitter.com/toranb) builds REST services with python/django and rich javascript frontends with ember.js
+---

--- a/_posts/2014-01-16-meeting.md
+++ b/_posts/2014-01-16-meeting.md
@@ -1,18 +1,6 @@
 ---
-layout: default
+layout: post
 date: January 16th 2014
 time: 6:00 - 7:30 pm
 location: WebFilings 2900 University Blvd, Ames, IA 50010
----
-
-### Do's and Don'ts of High Performance JavaScript: How WebFilings New Open Source Project Improves the Mobile Experience
-
-HTML5 is progressing fast, and so is the performance of mobile devices.  However it is still a challenge to build ‘native’ like UI with HTML and JavaScript on mobile. 
-
-The topic of discussion will be around using a brand new virtualized scrolling component as a case study. This ScrollList component is intended to provide near-native performance for huge amounts of content in an application built entirely on HTML5 and JavaScript.
-
-This ScrollList component is the first component to be released as part of Web UIComponents - a library developed internally at WebFilings, but now being released as an Open Source project.
-
-Presented by [Tim McCall](https://github.com/mccalltd). Tim is a Senior Software Engineer at WebFilings in charge of our mobile document viewer initiative. Tim is also responsible for the Attribute Routing project which was incorporated by Microsoft into ASP.NET MVC 5.
-
-Note - Food and drinks will be served starting @ 5:30
+---

--- a/_posts/2014-02-11-meeting.md
+++ b/_posts/2014-02-11-meeting.md
@@ -1,19 +1,6 @@
 ---
-layout: default
+layout: post
 date: February 11th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-### Intro Topic * Unit testing methods/modules in isolation with QUnit
-
-Have you ever wanted to run a single unit test while you do test driven development in javascript? Are you using Karma and QUnit? During this talk I'll show how to add a plugin to the default karma test runner that lets you get fast feedback as you build your application test-first. This talk will be a basic intro to the plugin/karma/qunit and should be under 15 minutes.
-
-[Jarrod Taylor](https://github.com/JarrodCTaylor) is a programmer with an interest in all things open source. He has spent the last seven years working in Des Moines at a variety of locations including Wells Fargo, Wellmark, and Aviva. Recently Jarrod has settled in as a senior programmer analyst with a small but talented bunch of developers at The IMT Group.
-
-### Advanced Topic * IndexedDB Fundamentals
-
-For this presentation, we will focus primarily on client-side usage of IndexedDB; specifically, a brief technical overview, then lots of “live coding” to show the syntax for CRUD operations on the client side as well as demonstrate the transactional system that is fundamental to IndexedDB.  We’ll look at the tools available in Chrome to help debug / analyze / manipulate data, and then finish up by a brief discussion of real-world use cases, as well as limitations of IndexedDB.
-
-Nicholas Starke is a Haskell / JavaScript programmer who enjoys pushing the envelope with JS by working on weird things like using javascript in embedded systems and synthesizing audio signals in the browser to create music compositions. Oh, and “vi forever”.
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-03-11-meeting.md
+++ b/_posts/2014-03-11-meeting.md
@@ -1,31 +1,6 @@
 ---
-layout: default
+layout: post
 date: March 11th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-### First Topic * Demystifying the ember object model
-
-Are you curious what this Ember.Object thing is all about? How similar is it to a traditional javascript object anyway? During this 15 minute talk I'll show how the basic ember object is put together and how to take advantage of its more classicial inheritance paradigm. All this and tests!
-
-[Toran Billups](https://twitter.com/toranb) is a Software Engineer at IMT Computer Services. When he isn't pair programming on the greatest python team in the Midwest, you can find him evangelizing ember.js or teaching python to 5th graders.
-
-Toran has been an active member of the Des Moines Python community for the past two years, where he frequently talks about testing and building modern web applications with Django. He also organizes the Des Moines JavaScript user group, where he encourages others to embrace their inner front-end engineer.
-
-### Middle Topic * Intro to gulp
-
-Here is a gentle introduction to Gulp and a brief comparison of Gulp and Grunt. A brief explanation of why all web developers should be using at least one of these two tools for all their projects.
-
-[Brandon Williams](https://twitter.com/williamsbdev) is a programmer at IMT working in Python and JavaScript/CoffeeScript. He is passion about Test Driven Development and learning something new every day.
-
-### Last Topic * Lets talk about real time web applications!  
-
-In this 25 minute run down we will delve into the socket.io library and how you can get up and running with it in minutes.  The server / client relationship will be demystified, we will squash the optimistic rendering paradigm, and chances are you will be ready to implement your own chat room protocol that's on par with IRC.
-
-Okay so maybe that may be a bit ambitious, but i've been playing with socket.io a lot lately and i'd like to share my experiences with my favorite community in Des Moines!
-
-Who knows, you may even get some JS related stickers just for showing up!
-
-[Joel Taddei](https://twitter.com/taddeimania) is primarily a Python and Javascript developer with a few years of experience under his belt.  He blows off steam in the evenings with a fine single malt scotch and his favorite hobby: game development.  He just welcomed the newest member of his family Logan James in early February so come pat him on the back, talk scotch, or tell him his games suck. Either way it'll be a good time.
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-04-08-meeting.md
+++ b/_posts/2014-04-08-meeting.md
@@ -1,21 +1,6 @@
 ---
-layout: default
+layout: post
 date: April 8th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-### First Topic * Unit and Integration testing: better together
-
-The biggest challenge adopting test driven development is knowing when to write a unit test and/or integration test as you write new features or fix production bugs. During this short talk I'll test drive adding a new feature using both unit and integration tests. The focus of this talk is the inner dialog I have along the way (asking myself when each type of test is valuable and why).
-
-[Toran Billups](https://twitter.com/toranb) is a Software Engineer at IMT Computer Services. When he isn't pair programming on the greatest python team in the Midwest, you can find him evangelizing ember.js or teaching python to 5th graders.
-
-Toran has been an active member of the Des Moines Python community for the past two years, where he frequently talks about testing and building modern web applications with Django. He also organizes the Des Moines JavaScript user group, where he encourages others to embrace their inner front-end engineer.
-
-### Last Topic * Intro to Web Components
-
-Web Components might not be ready for use yet, but they are ramping up to take over the world of front end development. In this talk, I'll go over the 5 building blocks that make up web components and try to tie them back to the technologies you are probably using today.
-
-[Eric Ponto](https://twitter.com/ericponto) is a web developer at Principal Financial Group. His life pretty much revolves around the 3 Fs: family, football, and front-end development (not necessarily in that order, depending on the day). You can follow Eric on Twitter @EricPonto (or if you're a big Iowa Football fan, @FightForIowa)
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-05-13-meeting.md
+++ b/_posts/2014-05-13-meeting.md
@@ -1,27 +1,6 @@
 ---
-layout: default
+layout: post
 date: May 13th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-### First Topic * KnockoutJS
-
-Love MVVM? Hate storing state in the DOM and complex DOM manipulation? Don't want to deal with Angular's routes, modules and service factory factories? Want excellent browser compatibility? Knockout JS just may be what you're looking for. Swing by this session and let Knockout knock your socks off.
-
-[Jon von Gillern](https://twitter.com/vongillern) is a C# MVP and Consultant from West Des Moines, Iowa. He helps lead the IADNUG and the Iowa Code Camp. He has three free products for developers, Nitriq Code Analysis (www.nitriq.com), Atomiq Code Duplication Finder (www.getatomiq.com) and Regex Pixie (www.regexpixie.com).
-
-### Middle Topic * Firebase
-
-Ever tried to make a realtime web application? Servers, scaling, cross browser compatibility issues, syncing, security... what a pain!
-
-Luckily, Firebase is here to save the day. We'll learn how to make a realtime web application with no servers and no fuss! Topics covered include: a brief overview, reading & writing data, authentication, and deployment.
-
-[Brad Dwyer](https://twitter.com/braddwyer) is the founder of Hatchlings and has been running Firebase in production for almost 2 years.
-
-### Last Topic * Using ES6 modules today
-
-Do you want to use the next generation of javascript modules today? Join me for a live coding session where I show how to write es6 modules and transpile them to AMD. Specifically I'll be showing off the es6-module-transpiler. If we have time I'll also show a bower demo where you can install and import modules on demand without having to worry about order dependent scripts (even for scripts with nested dependencies).
-
-[Toran Billups](https://twitter.com/toranb) is a excited about all things javascript.
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-06-10-meeting.md
+++ b/_posts/2014-06-10-meeting.md
@@ -1,20 +1,6 @@
 ---
-layout: default
+layout: post
 date: June 10th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-
-### Testing async node functions with mocha and jasmine 2.0
-
-Unit testing synchronous code in javascript is fairly straight forward, but what about async functions? Join me for a live coding session where I test drive a simple gulp task using mocha! I'll also show how to test basic async behavior with the latest jasmine framework.
-
-[Toran Billups](https://twitter.com/toranb) is a excited about all things javascript.
-
-### JavaScript Prototypes
-
-Have you ever come across JavaScript source that contained some weird thing called prototype? Did you think "Oh crap, I'm in too deep!" and just move onto something else? Prototypes in JavaScript are quite a bit different than most other popular languages. I will talk about what it is and demonstrate how to use it.
-
-[Matthew J. Morrison](https://twitter.com/mattjmorrison) is a passionate, professional software developer & hobbyist; Language nerd & regular user of Unix, Python, Ruby & JavaScript.
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-07-08-meeting.md
+++ b/_posts/2014-07-08-meeting.md
@@ -1,22 +1,6 @@
 ---
-layout: default
+layout: post
 date: July 8th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-
-### Writing your first react component
-
-React is a JavaScript library for building user interfaces. It's declarative, efficient, and extremely flexible. But what does all this mean exactly? Join me for a live coding session where I show off a few of the basic concepts required to write your first react component!
-
-### Building your web apps with gulp
-
-Does your web app require a build step of some kind? Is the declarative style used by grunt not your thing? Looking for a build tool made for the javascript developer? Join me for a live coding session where I create a simple gulp build that includes a JSX transform / ES6 transpile and even a simple concat step!
-
-### Browserify basics
-
-Are you looking for an easy way to bundle your javascript apps while allowing your team to leverage all of npm at the same time? Are you a fan of CJS style modules in javascript? Join me for a live coding session where I discuss my love/hate relationship with browserify!
-
-[Toran Billups](https://twitter.com/toranb) is a excited about all things javascript.
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-08-12-meeting.md
+++ b/_posts/2014-08-12-meeting.md
@@ -1,14 +1,6 @@
 ---
-layout: default
+layout: post
 date: August 12th 2014
 time: 6:00 - 7:30 pm
 location: The IMT Group 4445 Corporate Dr, West Des Moines, IA 50266
----
-
-### React / Routing / Lazy Loading and ES6
-
-On the surface web components seem like a great way to get started, but as your JavaScript application grows how do you compose them together in a maintainable way? How can you add client side routing to keep your application from breaking the web? What about lazy loading entire modules inside your application on the fly? Join me for a live coding session where I show all the above incrementally by building out a JavaScript application with react and the react-router!
-
-[Toran Billups](https://twitter.com/toranb) is a excited about all things javascript.
-
-Note - pizza will be provided @ 6pm
+---

--- a/_posts/2014-09-09-meeting.md
+++ b/_posts/2014-09-09-meeting.md
@@ -1,29 +1,6 @@
 ---
-layout: default
+layout: post
 date: September 9th 2014
 time: 6:15 - 7:45 pm
 location: Principal Financial Group Corporate 2 (The tower) 650 8th st.
----
-
-#dsmJS Moved!
-We are now being hosted at [Principal Financial Group's tower building](https://www.google.com/maps/place/650+8th+St,+Des+Moines,+IA+50309/@41.5893756,-93.6300676,325m/data=!3m1!1e3!4m12!1m9!4m8!1m3!2m2!1d-93.6291185!2d41.5892106!1m3!2m2!1d-93.6293418!2d41.5897773!3m1!1s0x87ee9904793d3753:0xe0d843d0d4df066f). Since it's downtown we have moved the time to 6:15, so that you can park on the street or in our [visitor parking lot.](https://www.google.com/maps/dir//41.5897773,-93.6293418/@41.5897589,-93.6333983,1249m/data=!3m2!1e3!4b1!4m3!4m2!1m0!1m0). 
-**Please send an email to dsmjs@epicness.com with your First and Last name. That way we can get your security badge created ahead of schedule. Otherwise, you can get it created at the door.**
-
-If you experience any problems getting in or need directions please call Chuck @ 515-238-7385.
-
-
-### Creating a realtime auction
-Going in depth on a real world project we will build an auction system from scratch using Firebase and Node.js. Topics covered will include Firebase security rules and design, and the "server as a privileged client" model.
-
-[Brad Dwyer](https://twitter.com/braddwyer) Founder of Hatchlings, Internet entrepreneur.
-
-
-### Intro to Absurd.js
-
-Absurd.js started out as a JavaScript based CSS preprocessor. It has now grown into a framework with HTML preprocessing, dependency injection, and components.
-
-In this talk we will go through the basic of building an application using Absurd.js.
-
-[Eric Ponto](https://twitter.com/ericponto) is it flashy and new? If so, he's interested.
-
-Note - pizza will be provided @ 6:15pm
+---

--- a/_posts/2014-10-14-meeting.md
+++ b/_posts/2014-10-14-meeting.md
@@ -1,9 +1,6 @@
 ---
-layout: default
+layout: post
 date: October 14th 2014
 time: Not meeting
 location: None
----
-
-#Des Moines Tech Week
-We were planning on joining up with another DSM Tech Week event, but unfortunately we had some mis-communications. Due to improper planning on our part we were not ready for an on campus meet-up, so we will be canceling this months meet-up. We are sorry about the inconvenience and look forward to seeing you in November. In the meantime please look at the other [Des Moines Tech Week events.](http://techweekdesmoines.com/)
+---

--- a/_posts/2014-10-14-meeting.md
+++ b/_posts/2014-10-14-meeting.md
@@ -1,6 +1,0 @@
----
-layout: post
-date: October 14th 2014
-time: Not meeting
-location: None
----

--- a/_posts/2014-11-12-meeting.md
+++ b/_posts/2014-11-12-meeting.md
@@ -1,25 +1,6 @@
 ---
-layout: default
+layout: post
 date: November 12th 2014
 time: 6:15pm - 7:45pm
 location: Principal Financial Group Corporate 2 (The tower) 650 8th st.
----
-
-#Remember, new location
-We are now being hosted at [Principal Financial Group's tower building](https://www.google.com/maps/place/650+8th+St,+Des+Moines,+IA+50309/@41.5893756,-93.6300676,325m/data=!3m1!1e3!4m12!1m9!4m8!1m3!2m2!1d-93.6291185!2d41.5892106!1m3!2m2!1d-93.6293418!2d41.5897773!3m1!1s0x87ee9904793d3753:0xe0d843d0d4df066f). Since it's downtown we have moved the time to 6:15, so that you can park on the street or in our [visitor parking lot.](https://www.google.com/maps/dir//41.5897773,-93.6293418/@41.5897589,-93.6333983,1249m/data=!3m2!1e3!4b1!4m3!4m2!1m0!1m0). 
-**Please send an email to dsmjs@epicness.com with your First and Last name. That way we can get your security badge created ahead of schedule. Otherwise, you can get it created at the door.**
-
-If you experience any problems getting in or need directions please call Chuck @ 515-238-7385.
-
-### Javascript Cryptography
-Advances in JavaScript cryptography have resulted in several libraries made available that can perform client side encryption.  We’ll look at two of the most common, SJCL and CryptoJS, along with the WebCrypto API that the W3C is currently drafting.  Finally, we’ll look at the practical applications and pitfalls of using client side encryption and discuss real world use cases.  
-
-[Nick Starke](https://twitter.com/nstarke) is an information security developer with an interest in all things crypto.
-
-
-### Intro To ES6
-Sometimes with JavaScript you have to write some funky code and we all just accept it, because that's the way it is. Want to loop over the `arguments` passed into a function? Better use `Array.protototype.slice` on that bad boy first. Trying to do inheritance? Good luck.
-
-With the next generation of the language, some of these common problems become very easy. In this talk, we'll go over some of the new features of JavaScript and how to start using them today.
-
-[Eric Ponto](https://twitter.com/ericponto) is it flashy and new? If so, he's interested.
+---

--- a/_posts/2015-01-07-meeting.md
+++ b/_posts/2015-01-07-meeting.md
@@ -1,24 +1,6 @@
 ---
-layout: default
+layout: post
 date: January 13th 2015
 time: 6:15pm - 7:45pm
 location: Principal Financial Group - 655 8th St.
----
-
-### Building Static Sites with Jekyll
-Learn how to build a site using the static site generator Jekyll. This talk will walk through the basics of Jekyll as well as hosting the site using Github Pages.
-
-(Bonus! This site, dsmjs.com, is built with Jekyll and hosted on Github pages.)
-
-[Justin Musgrove](https://twitter.com/jstnm) lives in Wisconsin, but we'll let him talk in Des Moines.
-
-
-### Intro to AngularJS
-Tired of hearing about Ember? We finally have a talk about Angular at DSMJS! Learn the basics of Angular and how it can help you quickly develop JavaScript apps.
-
-[Jessa Sparks](https://twitter.com/jessasparks) is a developer at Principal Financial Group.
-
-##If you still haven't been to Princial
-We are continuing to be hosted at [Principal Financial Group's tower building](https://www.google.com/maps/place/650+8th+St,+Des+Moines,+IA+50309/@41.5893756,-93.6300676,325m/data=!3m1!1e3!4m12!1m9!4m8!1m3!2m2!1d-93.6291185!2d41.5892106!1m3!2m2!1d-93.6293418!2d41.5897773!3m1!1s0x87ee9904793d3753:0xe0d843d0d4df066f). Since it's downtown we have moved the time to 6:15, so that you can park on the street or in our [visitor parking lot.](https://www.google.com/maps/dir//41.5897773,-93.6293418/@41.5897589,-93.6333983,1249m/data=!3m2!1e3!4b1!4m3!4m2!1m0!1m0). 
-
-If you experience any problems getting in or need directions please call Eric @ 319-431-7420.
+---

--- a/_posts/2015-02-03-meeting.md
+++ b/_posts/2015-02-03-meeting.md
@@ -1,19 +1,6 @@
 ---
-layout: default
+layout: post
 date: February 10 2015
 time: 6:15pm - 7:45pm
 location: Principal Financial Group - 655 8th St.
----
-
-### Phaser.js
-Phaser is a gaming engine developed entirely in JavaScript. Phaser does the work of calculating gravity, collision-detection, level advancement, sprite animation and much more.
-
-Come learn the basics of Phaser and how to make a quick, web-based game.
-
-[David Moritz](http://www.davidmoritz.net) works with front-end development at Principal Financial Group. He is happily married to his wife, Megan, and they are new owneers of a home in Norwalk. He enjoys coding, chess, snowboarding and European-sylte board games.
-
-### Going Async with Promises and Generators
-Writing asynchronous code can be tough and you can quickly find yourself in callback inception. But with <s>ES6</s> ES2015's promises and generators, going async is now a little easier. Learn how promises help manage your callbacks and how generators give you finer control on when thing execute.
-
-[Eric Ponto](http://www.ericponto.com) is talking again! 
-
+---

--- a/_posts/2015-03-09-meeting.md
+++ b/_posts/2015-03-09-meeting.md
@@ -1,18 +1,6 @@
 ---
-layout: default
+layout: post
 date: March 10 2015
 time: 6:15pm - 7:45pm
 location: Principal Financial Group - 655 8th St.
----
-
-### Responsive Tables with Tablesaw
-
-Tablesaw is a collection of plugins for responsive tables. It does all the heavy lifting for a number of scenarios, it lets you apply rules to determine the presentation layout and priority of columns.  It also gives a wide array of options to users so they can view data how they would like to. With at least 5 different main options you can add into tables it gives you a wide variety of options with minimal development time.
-
-**Korina Borowycz**
-
-### Handlebars.js - Minimal Templating on Steroids
-
-Handlebars lets you build semantic client side templates quickly and easily.
-
-**Thomas Lindner**
+---

--- a/_posts/2015-04-14-meeting.md
+++ b/_posts/2015-04-14-meeting.md
@@ -1,22 +1,6 @@
 ---
-layout: default
+layout: post
 date: April 14 2015
 time: 6:15pm - 7:45pm
 location: Principal Financial Group - 655 8th St.
----
-
-### Future proof your javascript with Babel (formerly 6to5)
-
-Do you love reading about all of the cool features of ECMAScript 6 and want to start using them in production today? You might just be a build step away!  We'll explore the cool things you could be writing right NOW with Babel.  We'll also chat about Grunt integration.
-
-<small>This is also the last talk Joel will be giving before he leaves town for a new job so come join us at Up/Down after for arcade games.</small>
-
-**Joel Taddei**
-[@taddeimania](https://twitter.com/taddeimania)
-
-
-### Vagrant
-Ever inherit an app only to spend hours or days trying to get it to run locally? Tried running apps locally on one OS when production servers use a different OS? Tried something new and completely messed up your workstation? Wondered if there’s a better way? Vagrant is a tool for solving these challenges. It relies on virtualization and automation tools to quickly spin up local development environments. Easily blow away and recreate environments after screwing them up. Generally make life easier for devs working with the app, allow them to focus on adding new features, and not wasting time getting their local environment setup.
-
-**Shawn Sparks**
-[@marshmellow1328](https://twitter.com/marshmellow1328)
+---

--- a/_posts/2015-05-12-meeting.md
+++ b/_posts/2015-05-12-meeting.md
@@ -1,22 +1,6 @@
 ---
-layout: default
+layout: post
 date: May 12 2015
 time: 6:15pm - 7:45pm
 location: Principal Financial Group - 655 8th St.
----
-
-### Functional Reactive Programming in JavaScript with RxJS
-
-What is functional programming? What is reactive programming? How do those things come together to make application with JavaScript?
-
-RxJS is a library that helps you manage asynchronous programming using observable streams. Observable steam? It's like a collection of events over time or like a series of promises. It is a powerful tool for managing data, events, concurrency, etc...
-
-**Eric Ponto**
-[@ericponto](https://twitter.com/ericponto)
-
-### AngularFire
-
-AngularFire is a lightweight resource the blends the two worlds of Angular and Firebase together. Extending the simplistic 2-way data-binding of Angular to be connected to a RESTful API allows for the coveted “3-way data-binding!” I will be showing examples of this 3-way data-binding and, more importantly, how easy it is to set up and bring your site to the next level. You can also set up authentication very easily using built-in plugins for Facebook, Twitter, and Google Plus sign-on.
-
-**David Moritz**
-[@daveymoritz](https://twitter.com/daveymoritz)
+---

--- a/_posts/2015-06-09-meeting.md
+++ b/_posts/2015-06-09-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: June 9th 2015
 time: 6:15pm - 7:45pm
 location: Principal Financial Group - 655 8th St.
@@ -7,21 +7,4 @@ pizzaSponsorName: Principal Financial Group
 pizzaSponsorSite: http://www.principal.com/
 tiklyWidgetID: tiklet_697
 tiklyWidgetURL: https://tikly.co/tiklets?token=1db75fc3e97f3c8430010f50f668c991b46b9547
----
-
-### Responsible Responsive Web Design
-
-Come learn what Responsive Design is and how to build a website using it. We'll also cover how to design a website responsibly - How you can deliver a consisten user experience to users on small and large screen devices and how to decrease your website's page size quickly and effectively to ensure your website loads fast even on slow internet connections. 
-
-**Matt Busche**
-[@mrbusche](https://twitter.com/mrbusche)
-Matt Busche is a programmer at Nationwide Insurance where he programs in Groovy, Grails, Java, ColdFusion, Ruby (for testing) and of course, JavaScript. He is a responsive design enthuisast and in passionate about making the web a better place for all users.
-
-
-### Umm, I created a presentation with Sailjs?
-
-Sailsjs is great for creating awesome backend applications. Its very quick to stand up an endpoint and fly forward. However, what if you wanted to use it as your presentation platform (like Revealjs)? This talk is focused around the flexibility that Sailjs provides it’s users. 
-
-**Chuck Rolek**
-[@crolek](https://twitter.com/crolek)
-Fueled by silliness and coffee Chuck tries to create efficiency in everything he and others do. His specialties are Front-end development, architecture, continuous integration, and bringing much needed innovation to enterprises. He absolutely love technology, and spends a vast majority of his time learning about it or teaching it.
+---

--- a/_posts/2015-08-10-meeting.md
+++ b/_posts/2015-08-10-meeting.md
@@ -1,19 +1,8 @@
 ---
-layout: default
+layout: post
 date: August 11 2015
 time: 6:15pm - 7:45pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-**Note** - This month's meet up is taking place at [Gravitate](http://www.gravitatedsm.com/) instead of its usual location.
-
-### `React.render(ClientOrServer, document.querySelector(‘.you-decide’));`
-
-It is hard to read any JavaScript news without mention of ReactJS. This talk is an introduction to React and why it's awesome. We will talk about the Virtual DOM, the data flow, and where it fits in the JavaScript stack. I will share some of my experiences with React both best practices and future plans.
-
-**Jason Bradley**
-[@jason_bradley](https://twitter.com/jason_bradley)
-Jason is a Software Engineer at John Deere. He loves all things JavaScript. He is an advocate of test driven development and automating all of the things. He uses modular development practices to create reusable components. He is also an Apple Fanboi.
-
+---

--- a/_posts/2015-09-08-meeting.md
+++ b/_posts/2015-09-08-meeting.md
@@ -1,18 +1,8 @@
 ---
-layout: default
+layout: post
 date: September 08 2015
 time: 6:15pm - 7:45pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-**Note** - This month's meet up is taking place at [Gravitate](http://www.gravitatedsm.com/) instead of its usual location.
-
-###Universal Javascript: Rendering React on the server and client
-
-Is your SPA was easily indexable, [Fast](https://blog.twitter.com/2012/improving-performance-on-twittercom), maintainable?  I will show how to server side render any initial request into a SPA with [hapi](http://hapijs.com/) and [React](http://facebook.github.io/react/), and then client side render any following requests.  Write your views in React once and don't worry where they render.
-
-***Logan Keenan*** [@dlogankeenan](https://twitter.com/dlogankeenan) is a Software Developer for TekSystems currently contracting at John Deere.  He's passion about Javascript, TDD, learning new technologies, and developing patterns to solve problems. 
-
-[Repo](https://github.com/dlogankeenan/universal-javascript-react-views) from the presentation
+---

--- a/_posts/2015-10-13-meeting.md
+++ b/_posts/2015-10-13-meeting.md
@@ -1,16 +1,8 @@
 ---
-layout: default
+layout: post
 date: October 13 2015
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-**Note** - This month's meet up is taking place at [Gravitate](http://www.gravitatedsm.com/) instead of its usual location.
-
-### Outside-In Test Driven Development
-
-Modern day single page apps incorporate acceptance tests, integration tests, and unit tests but when do write them and how do you choose what type to write and why? Join me for a 45 minute live coding session where I show a technique that's helped me build javascript applications sustainably from the outside in.
-
-[Toran Billups](https://twitter.com/toranb) Toran Billups is a software professional with a passion for all things javascript. When he isn't debating the tradeoffs of one-way vs two-way databinding you can find him teaching 5th grade students python!
+---

--- a/_posts/2015-11-10-meeting.md
+++ b/_posts/2015-11-10-meeting.md
@@ -1,20 +1,8 @@
 ---
-layout: default
+layout: post
 date: November 10 2015
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-**Note** - This month's meet up is taking place at [Gravitate](http://www.gravitatedsm.com/) instead of its usual location.
-
-### It hurts....so Good :)
-
-While the bleeding-edge can be painful, there is an incredible amount of power to be found
-in future versions of javascript.  We will be showing off some of the techniques and tools
-that TelePharm has been using to increase our productivity (We'd be going much faster if it wasn't for the new guy.) and code clarity as we build the next version of our application. Specifically, we will be
-demonstrating some useful patterns that have been previously unavailable in the javascript ecosystem.
-
-
-[Caleb Boyd](https://github.com/calebboyd) and [Dusty Greif](https://github.com/dgreif) are software engineers serially working in the start-up arena. Before starting at TelePharm, they created Keepalo, which failed. (because startups do that sometimes) Both can be found at [@calebboyd](https://github.com/calebboyd) and [@dgreif](https://github.com/dgreif) on github.
+---

--- a/_posts/2016-01-12-meeting.md
+++ b/_posts/2016-01-12-meeting.md
@@ -1,16 +1,8 @@
 ---
-layout: default
+layout: post
 date: January 12 2016
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Principal Financial Group
 pizzaSponsorSite: http://www.principal.com/
----
-
-**Note** - This month's meet up is taking place at [Gravitate](http://www.gravitatedsm.com/) instead of its usual location.
-
-### Redux: the beginner friendly introduction
-
-Does the word flux make you anxious? Does adding reducers, actions and a store to your JavaScript app sound like unnecessary complexity? Join me for a truly beginner friendly discussion about redux and why predictable state changes are the way forward!
-
-[Toran Billups](https://twitter.com/toranb) Toran Billups is a software professional with a passion for all things javascript. When he isn't debating the tradeoffs of one-way vs two-way databinding you can find him teaching 5th grade students python!
+---

--- a/_posts/2016-02-09-meeting.md
+++ b/_posts/2016-02-09-meeting.md
@@ -1,16 +1,8 @@
 ---
-layout: default
+layout: post
 date: February 9 2016
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Dynamo
 pizzaSponsorSite: http://godynamo.co/
----
-
-**Note** - This month's meet up is taking place at [Gravitate](http://www.gravitatedsm.com/) instead of its usual location.
-
-### Installing and Setting Up Node.js and npm: A Beginner Friendly Guide
-
-Node.js has rapidly become one of the most popular web frameworks. Its package manager, npm, has become the largest software module epository in the world with over 200,000 packages. With so many packages, the quality and compatibility issues can vary widely. Also, with so many new and better packages coming out, the most widely used packages may not necessarily be the best.
-
-[Jeff Donovan](https://twitter.com/_Jeff_D_) Jeff Donovan is a web developer in Des Moines.
+---

--- a/_posts/2016-03-08-meeting.md
+++ b/_posts/2016-03-08-meeting.md
@@ -1,16 +1,8 @@
 ---
-layout: default
+layout: post
 date: March 8 2016
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-### Building your own Command Line Interface with Node and npm
-
-Command Line Interfaces (CLIs) have been working their way into the front-end tooling space for a little while. Grunt and Gulp came out quite a few years ago and really changed the landscape. Now we are seeing specific CLIs build right into frameworks like Ember, Sails, or Express.
-
-In this talk, we'll dive into creating our own CLI using JavaScript and how to publish it to npm so anyone can use it.
-
-[Eric Ponto](https://twitter.com/ericponto)
+---

--- a/_posts/2016-04-12-meeting.md
+++ b/_posts/2016-04-12-meeting.md
@@ -1,13 +1,8 @@
 ---
-layout: default
+layout: post
 date: April 12, 2016
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
 pizzaSponsorName: Principal
 pizzaSponsorSite: https://www.principal.com/
----
-
-### Make money freelancing
-Over the last 15 years I've taken on several freelance projects. Some of these worked great and some were disasters. I'll share the tips for finding interesting challenges and ensuring that projects have a high chance of success. I'll cover how to charge, how much to charge, and ensuring that expectations are clear and met.
-
-[Matthew Nuzum](https://twitter.com/newz2000)
+---

--- a/_posts/2016-05-11-meeting.md
+++ b/_posts/2016-05-11-meeting.md
@@ -1,16 +1,8 @@
 ---
-layout: default
+layout: post
 date: May 11, 2016
 time: 6:15pm - 7:00pm
 location: 4501 NW Urbandale Dr
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-*Note: New time and place this month. We are meeting on <b>Wednesday</b> at Source Allies' new building: 4501 NW Urbandale Dr., Urbandale, 50322*
-
-### Functional Programming in Ember? The Ember-Redux Origin Story
-
-I've become more interested in functional programming this year but didn't know how exactly I could bring that experience to ember. After a few hours cargo culting the react-redux api it was clear I had something that would forever change the way I wrote ember web applications. Join me for a live coding demo where I bring the mythical "functional core, imperative shell" concept to reality!
-
-[Toran Billups](https://twitter.com/toranb) Toran Billups is a software professional with a passion for all things javascript. When he isn't debating the tradeoffs of one-way vs two-way databinding you can find him teaching 5th grade students python!
+---

--- a/_posts/2016-06-14-meeting.md
+++ b/_posts/2016-06-14-meeting.md
@@ -1,17 +1,8 @@
 ---
-layout: default
+layout: post
 date: June 14, 2016
 time: 6:15pm - 7:00pm
 location: 4501 NW Urbandale Dr
 pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
----
-
-*Note: New time and place this month. We are meeting on <b>Tuesday</b> at Source Allies' new building: 4501 NW Urbandale Dr., Urbandale, 50322*
-
-### Chrome App and Extension crash course
-
-Browser Apps/Extensions can be super helpful for day to day use. Making a Chrome App or Extension actually isn't as hard as it might seem. However, there are some differences between a Chrome App and Extension that might make a difference between which one you go with. I’ll go over creating a basic one, some of the standard API items, and some of the tips/tricks I learned while making one of each. Hopefully by the end of this you could go home and create your own App/Extension.
-
-[@crolek](https://twitter.com/crolek)
-Fueled by silliness and coffee Chuck tries to create efficiency in everything he and others do. He absolutely love technology, and spends a vast majority of his time learning about it or teaching it.
+---

--- a/_posts/2016-07-12-meeting.md
+++ b/_posts/2016-07-12-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: July 12, 2016
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
@@ -7,21 +7,4 @@ pizzaSponsorName: Dynamo
 pizzaSponsorSite: http://godynamo.co/
 tiklyWidgetID: tiklet_1407
 tiklyWidgetURL: https://tikly.co/tiklets?token=74c34f2a6296ecb25046e49eba25679341325436
----
-
-### Collaborating through a _shared_ component library
-
-A style guide or component-library has the potential to be huge help in keeping
-your engineering teams up to date on the latest intended design details. Over
-time however, it ultimately severely diverges from the production implementation
-and ends up resulting in finger-pointing between the design and engineering
-organizations.
-
-Sharing the implementation of the front-end components between the production
-application and the component-library demo and prototype(s) prevents the inevitable
-divergence and keeps all parties aware of the impacts of desired changes. This talk
-will highlight component-library tools and collaboration techniques, with an emphasis
-on leveraging npm to share the component implementation.
-
-[Matt Travi](https://matt.travi.org) is a full-stack engineer at Dwolla with a
-passion for front-end, APIs, and continuous deployment.
+---

--- a/_posts/2016-08-09-meeting.md
+++ b/_posts/2016-08-09-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: August 9, 2016
 time: 6:15pm - 7:00pm
 location: 4501 NW Urbandale Dr
@@ -7,10 +7,4 @@ pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
 tiklyWidgetID: tiklet_1458
 tiklyWidgetURL: https://tikly.co/tiklets?token=af143dc31c40b35e07e785ab62c9d5d1d4bc9485
----
-
-### Robotics with JavaScript
-
-Learn how to leverage Node.JS on Raspberry Pi and Arduino microcontrollers to build small robots and IoT devices. Examples will include working with general purpose input/output, using servos and motors, communicating using radio transceivers, and interacting with LEDs and LCD screens.
-
-[Michael Parker](https://github.com/Mrparkers) is a consultant at Source Allies and a student at Iowa State University.  He's passionate about all things JavaScript and interested in learning about everything the language has to offer.
+---

--- a/_posts/2016-09-13-meeting.md
+++ b/_posts/2016-09-13-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: September 13, 2016
 time: 6:15pm - 7:00pm
 location: 1420 Locust st
@@ -10,12 +10,4 @@ pizzaSponsorName: Pillar Technology
 pizzaSponsorSite: http://pillartechnology.com/
 tiklyWidgetID: tiklet_1514
 tiklyWidgetURL: https://tikly.co/tiklets?token=257d56203402f066ef688ee3444898527e21769c
----
-
-### Refactor Like a Scientist
-
-Tests are a good baseline for defining the behavior of a program. Though, on complicated programs, are tests enough?
-
-[Scientist](https://github.com/trello/scientist) is a [Node.js](https://nodejs.org/en/) library for creating and running experiments between old and new pieces of code. Scientist makes it easy to refactor critical code paths with confidence. It safely exposes refactorings to actual production interactions and measures potential mismatches. Part experience report, refactoring discussion, and workshop, this talk will also explore safe refactoring techniques at companies like Trello and [GitHub](https://github.com/).
-
-About Fred Galoso ([@wayoutmind](http://twitter.com/wayoutmind)) is a software developer for [Trello](http://trello.com/). Trusted by millions of people and companies of all kinds and sizes, Trello is a visual collaboration tool that creates a shared perspective on any project. Prior to Trello, Fred led data and analytics efforts at [Dwolla](http://dwolla.com/) and has spoken at national and regional conferences about software engineering, data architecture, and visualization.
+---

--- a/_posts/2016-10-11-meeting.md
+++ b/_posts/2016-10-11-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: October 11, 2016
 time: 6:15pm - 7:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
@@ -10,14 +10,4 @@ pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
 tiklyWidgetID: tiklet_1595
 tiklyWidgetURL: https://tikly.co/tiklets?token=e2c37587a6431e44bf3d770368809a70e016d910
----
-
-# Last minute move to Graviate!
-
-### The future! A story about the vNext developer toolchain
-
-On large teams we spend a great deal of time providing accurate and concise instructions to reproduce a problem when QA finds an issue. What if instead we could export the state of the application and attach it as an artifact for the developer for further debugging and verification?
-
-In this talk I'll discover a bug and show a QA/Dev workflow that I believe is the future of QA and Dev collaboration.
-
-[Toran Billups](https://twitter.com/toranb) Toran Billups is a software professional with a passion for all things javascript. When he isn't learning functional programming you can find him teaching 5th grade students python!
+---

--- a/_posts/2016-11-15-meeting.md
+++ b/_posts/2016-11-15-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: November 15, 2016
 time: 6:15pm - 7:00pm
 location: The Forge - 1420 Locust st
@@ -9,16 +9,4 @@ zip: 50310
 pizzaSponsorName: Pillar Technology
 pizzaSponsorSite: http://pillartechnology.com/
 
----
-
-#### **Note:** Change In Date -- November 15 (Go vote on the 8th!)
-
-### From Rx to Redux and Back
-
-Change management is hard. When my model changes, how do I reflect that in my view? Hundreds of JavaScript libraries and frameworks have been built trying to solve that seemingly simple questions. This talk will seek to answer that question by follow my own journey of adopting the unidirectional data flow pattern that React has popularized.
-
-First we will dig in to the basic of Reactive Programming using RxJS and learn about using Observables to deal with asynchronous streams. Next we will explorer how Redux makes state management easier taking cues from the Elm Architecture which clearly separates the concerns of Models, Views, and Actions. And finally, we'll take lessons learned from Redux and apply them back to RxJS.
-
-[Eric Ponto](https://twitter.com/ericponto)
-
-
+---

--- a/_posts/2017-01-10-meeting.md
+++ b/_posts/2017-01-10-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: January 10, 2017
 time: 6:15pm - 7:00pm
 location: 4501 NW Urbandale Dr
@@ -10,10 +10,4 @@ pizzaSponsorName: Source Allies
 pizzaSponsorSite: http://www.sourceallies.com/
 tiklyWidgetID: tiklet_1725
 tiklyWidgetURL: https://tikly.co/tiklets?token=3e7c61c7522719bcb492a1e3c2eafad05b784223
----
-
-### VueJS
-
-VueJS, databinding for the rest of us
-
-Paul Rowe is a consultant at Source Allies. With nearly 10 years of software development experience, Paul enjoys dabbling in new technologies and discussing different solutions to any technical problems. Most recently, Paul is leading architecture design and development in C# and Node.js on Azure.
+---

--- a/_posts/2017-02-15-meeting.md
+++ b/_posts/2017-02-15-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: February 15, 2017
 time: 6:00pm - 8:00pm
 location: Gravitate, 206 6th Ave, 3rd Floor
@@ -10,16 +10,4 @@ pizzaSponsorName: Keyhole Software
 pizzaSponsorSite: https://keyholesoftware.com/
 tiklyWidgetID: tiklet_1786
 tiklyWidgetURL: https://tikly.co/tiklets?token=b3378ad21994ce543e09d19ed1ae2fa13f6cac07
----
-
-#### **Note:** We're meeting on **Wednesday**, February 15 (Enjoy Valentine's Day!)
-
-### From Angular 1 to Angular 2
-
-AngularJS is one of the most popular JavaScript frameworks available for creating web applications. The switch from Angular 1 and adoption of Angular 2 has been a source of anxiety for members of the enterprise. That concern is what we seek to alleviate in this talk.
-
-Keyhole Principal Consultant Jaime Niswonger will present a live demonstration of Angular 2 in action.
-
-Jaime will build an example Angular 2 application applicable to enterprise use. He will point out unique features and approaches the Angular 2 framework introduces, with an eye for potential pitfalls. The presentation will show how it contrasts from Angular 1 and other comparable JavaScript frameworks, in addition to a contrast from existing development patterns and techniques.
-
-The presentation will be followed with a Q&A session.
+---

--- a/_posts/2017-03-14-meeting.md
+++ b/_posts/2017-03-14-meeting.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 date: March 14, 2017
 time: 6:15pm - 7:00pm
 location: The Forge - 1420 Locust st
@@ -10,12 +10,4 @@ pizzaSponsorName: Pillar Technology
 pizzaSponsorSite: http://pillartechnology.com/
 tiklyWidgetID: tiklet_1871
 tiklyWidgetURL: https://tikly.co/tiklets?token=89fc9ee32a1867236a3e1e42f354586c70ed887e
----
-
-### Angular 2: First Look
-
-Haven’t had a chance to dig into Angular2 yet? Waiting until it “stabilizes” before spending your time to learn it? Tried out some of the “Quick Starts” only to find out they weren’t so quick? You’re not alone.
-
-In this session, I will show you the basics of the newest version of AngularJS, the differences from Angular 1.x, and even show you the Angular-CLI which makes it drop-dead simple to get (and keep) an organized Angular2 project underway. I will even show you where Angular2 doesn’t shine so bright. You will leave with a better understanding of Angular2 and the knowledge to get started on the right path with the newest version of AngularJS!
-
-Lee Brandt
+---

--- a/_scss/_talk.scss
+++ b/_scss/_talk.scss
@@ -1,0 +1,15 @@
+.talk-title {
+	color: $purple;
+	margin-bottom: 0.25em;
+}
+
+.meeting-title {
+	margin-bottom: 0.25em;
+	margin-top: 1em;
+}
+
+.talk-card {
+	margin-bottom: 0.5em;
+	margin-left: 1em;
+	color: $blue;
+}

--- a/_talks/a-gentle-introduction-to-emberjs.md
+++ b/_talks/a-gentle-introduction-to-emberjs.md
@@ -1,0 +1,10 @@
+---
+title: a gentle introduction to ember.js
+date: August 20, 2013
+tags: Ember
+speaker: Toran Billups
+twitter: toranb
+---
+
+As the ember.js javascript framework matures to 1.0 what does the "hello world" experience look like today? What does each component in the framework do and what are the naming conventions required to wire them up? What is the story behind the new router api and how do you work with nested routes/controllers? What is the persistence story?
+

--- a/_talks/angular-2---first-look.md
+++ b/_talks/angular-2---first-look.md
@@ -1,0 +1,15 @@
+---
+title: Angular 2 -  First Look
+date: March 14, 2017
+tags: Angular
+speaker: Lee Brandt
+---
+
+
+
+Haven’t had a chance to dig into Angular2 yet? Waiting until it “stabilizes” before spending your time to learn it? Tried out some of the “Quick Starts” only to find out they weren’t so quick? You’re not alone.
+
+In this session, I will show you the basics of the newest version of AngularJS, the differences from Angular 1.x, and even show you the Angular-CLI which makes it drop-dead simple to get (and keep) an organized Angular2 project underway. I will even show you where Angular2 doesn’t shine so bright. You will leave with a better understanding of Angular2 and the knowledge to get started on the right path with the newest version of AngularJS!
+
+
+

--- a/_talks/angularfire.md
+++ b/_talks/angularfire.md
@@ -1,0 +1,15 @@
+---
+title: AngularFire
+date: May 12, 2015
+tags:
+  - Angular
+  - Firebase
+speaker: David Moritz
+twitter: daveymoritz
+---
+
+
+
+AngularFire is a lightweight resource the blends the two worlds of Angular and Firebase together. Extending the simplistic 2-way data-binding of Angular to be connected to a RESTful API allows for the coveted “3-way data-binding!” I will be showing examples of this 3-way data-binding and, more importantly, how easy it is to set up and bring your site to the next level. You can also set up authentication very easily using built-in plugins for Facebook, Twitter, and Google Plus sign-on.
+
+

--- a/_talks/browserify-basics.md
+++ b/_talks/browserify-basics.md
@@ -1,0 +1,13 @@
+---
+title: Browserify basics
+date: July 8, 2014
+tags: Browserify
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Are you looking for an easy way to bundle your javascript apps while allowing your team to leverage all of npm at the same time? Are you a fan of CJS style modules in javascript? Join me for a live coding session where I discuss my love/hate relationship with browserify!
+
+

--- a/_talks/building-static-sites-with-jekyll.md
+++ b/_talks/building-static-sites-with-jekyll.md
@@ -1,0 +1,14 @@
+---
+title: Building Static Sites with Jekyll
+date: January 13, 2015
+tags: Jekyll
+speaker: Justin Musgrove
+twitter: jstnm
+---
+
+
+Learn how to build a site using the static site generator Jekyll. This talk will walk through the basics of Jekyll as well as hosting the site using Github Pages.
+
+(Bonus! This site, dsmjs.com, is built with Jekyll and hosted on Github pages.)
+
+

--- a/_talks/building-your-own-command-line-interface-with-node-and-npm.md
+++ b/_talks/building-your-own-command-line-interface-with-node-and-npm.md
@@ -1,0 +1,16 @@
+---
+title: Building your own Command Line Interface with Node and npm
+date: March 8, 2016
+tags:
+  - CLI
+  - Node
+  - npm
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+
+Command Line Interfaces (CLIs) have been working their way into the front-end tooling space for a little while. Grunt and Gulp came out quite a few years ago and really changed the landscape. Now we are seeing specific CLIs build right into frameworks like Ember, Sails, or Express.
+
+In this talk, we'll dive into creating our own CLI using JavaScript and how to publish it to npm so anyone can use it.

--- a/_talks/building-your-web-apps-with-gulp.md
+++ b/_talks/building-your-web-apps-with-gulp.md
@@ -1,0 +1,9 @@
+---
+title: Building your web apps with gulp
+date: July 8, 2014
+tags: Gulp
+speaker: Toran Billups
+twitter: toranb
+---
+
+Does your web app require a build step of some kind? Is the declarative style used by grunt not your thing? Looking for a build tool made for the javascript developer? Join me for a live coding session where I create a simple gulp build that includes a JSX transform / ES6 transpile and even a simple concat step!

--- a/_talks/chrome-app-and-extension-crash-course.md
+++ b/_talks/chrome-app-and-extension-crash-course.md
@@ -1,0 +1,11 @@
+---
+title: Chrome App and Extension crash course
+date: June 14, 2016
+tags: Chrome
+speaker: Chuck Rolek
+twitter: crolek
+---
+
+
+
+Browser Apps/Extensions can be super helpful for day to day use. Making a Chrome App or Extension actually isn't as hard as it might seem. However, there are some differences between a Chrome App and Extension that might make a difference between which one you go with. I’ll go over creating a basic one, some of the standard API items, and some of the tips/tricks I learned while making one of each. Hopefully by the end of this you could go home and create your own App/Extension.

--- a/_talks/chrome-dev-tools-tips-and-tricks.md
+++ b/_talks/chrome-dev-tools-tips-and-tricks.md
@@ -1,0 +1,18 @@
+---
+title: Chrome dev tools tips and tricks
+date: June 13, 2013
+tags: Chrome
+speaker: Torey Maerz
+twitter: toreym
+---
+
+
+
+[Torey Maerz](https://twitter.com/toreym) will start off the meeting
+with a quick 30 minute tips and tricks overview for developing and
+debugging in chrome dev tools. He'll cover some helpful development
+workflow tips to help you work more efficiently, show you how you
+can use the profiler and network tabs to find inefficiencies in your
+code, and even some newer items just added to dev tools.
+
+

--- a/_talks/collaborating-through-a--shared--component-library.md
+++ b/_talks/collaborating-through-a--shared--component-library.md
@@ -1,0 +1,23 @@
+---
+title: Collaborating through a _shared_ component library
+date: July 12, 2016
+tags: Component Library
+speaker: Matt Travi
+twitter: mtravi
+---
+
+
+
+A style guide or component-library has the potential to be huge help in keeping
+your engineering teams up to date on the latest intended design details. Over
+time however, it ultimately severely diverges from the production implementation
+and ends up resulting in finger-pointing between the design and engineering
+organizations.
+
+Sharing the implementation of the front-end components between the production
+application and the component-library demo and prototype(s) prevents the inevitable
+divergence and keeps all parties aware of the impacts of desired changes. This talk
+will highlight component-library tools and collaboration techniques, with an emphasis
+on leveraging npm to share the component implementation.
+
+

--- a/_talks/creating-a-realtime-auction.md
+++ b/_talks/creating-a-realtime-auction.md
@@ -1,0 +1,11 @@
+---
+title: Creating a realtime auction
+date: September 9, 2014
+tags: Firebase
+speaker: Brad Dwyer
+twitter: braddwyer
+---
+
+
+Going in depth on a real world project we will build an auction system from scratch using Firebase and Node.js. Topics covered will include Firebase security rules and design, and the "server as a privileged client" model.
+

--- a/_talks/demystifying-the-ember-object-model.md
+++ b/_talks/demystifying-the-ember-object-model.md
@@ -1,0 +1,11 @@
+---
+title: Demystifying the ember object model
+date: March 11, 2014
+tags: Ember
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Are you curious what this Ember.Object thing is all about? How similar is it to a traditional javascript object anyway? During this 15 minute talk I'll show how the basic ember object is put together and how to take advantage of its more classicial inheritance paradigm. All this and tests!

--- a/_talks/dos-and-donts-of-high-performance-javascript---how-webfilings-new-open-source-project-improves-the-mobile-experience.md
+++ b/_talks/dos-and-donts-of-high-performance-javascript---how-webfilings-new-open-source-project-improves-the-mobile-experience.md
@@ -1,0 +1,14 @@
+---
+title: Do's and Don'ts of High Performance JavaScript -  How WebFilings New Open Source Project Improves the Mobile Experience
+date: January 16, 2014
+tags: Performance
+speaker: Tim McCall
+---
+
+
+
+HTML5 is progressing fast, and so is the performance of mobile devices.  However it is still a challenge to build ‘native’ like UI with HTML and JavaScript on mobile.
+
+The topic of discussion will be around using a brand new virtualized scrolling component as a case study. This ScrollList component is intended to provide near-native performance for huge amounts of content in an application built entirely on HTML5 and JavaScript.
+
+This ScrollList component is the first component to be released as part of Web UIComponents - a library developed internally at WebFilings, but now being released as an Open Source project.

--- a/_talks/firebase.md
+++ b/_talks/firebase.md
@@ -1,0 +1,14 @@
+---
+title: Firebase
+date: May 13, 2014
+tags: Firebase
+speaker: Brad Dwyer
+twitter: braddwyer
+---
+
+
+
+Ever tried to make a realtime web application? Servers, scaling, cross browser compatibility issues, syncing, security... what a pain!
+
+Luckily, Firebase is here to save the day. We'll learn how to make a realtime web application with no servers and no fuss! Topics covered include: a brief overview, reading & writing data, authentication, and deployment.
+

--- a/_talks/from-angular-1-to-angular-2.md
+++ b/_talks/from-angular-1-to-angular-2.md
@@ -1,0 +1,17 @@
+---
+title: From Angular 1 to Angular 2
+date: February 15, 2017
+tags: Angular
+speaker: Jaime Niswonger
+---
+
+
+
+AngularJS is one of the most popular JavaScript frameworks available for creating web applications. The switch from Angular 1 and adoption of Angular 2 has been a source of anxiety for members of the enterprise. That concern is what we seek to alleviate in this talk.
+
+Keyhole Principal Consultant Jaime Niswonger will present a live demonstration of Angular 2 in action.
+
+Jaime will build an example Angular 2 application applicable to enterprise use. He will point out unique features and approaches the Angular 2 framework introduces, with an eye for potential pitfalls. The presentation will show how it contrasts from Angular 1 and other comparable JavaScript frameworks, in addition to a contrast from existing development patterns and techniques.
+
+The presentation will be followed with a Q&A session.
+

--- a/_talks/from-rx-to-redux-and-back.md
+++ b/_talks/from-rx-to-redux-and-back.md
@@ -1,0 +1,17 @@
+---
+title: From Rx to Redux and Back
+date: November 15, 2016
+tags:
+  - RxJS
+  - Redux
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+
+Change management is hard. When my model changes, how do I reflect that in my view? Hundreds of JavaScript libraries and frameworks have been built trying to solve that seemingly simple questions. This talk will seek to answer that question by follow my own journey of adopting the unidirectional data flow pattern that React has popularized.
+
+First we will dig in to the basic of Reactive Programming using RxJS and learn about using Observables to deal with asynchronous streams. Next we will explorer how Redux makes state management easier taking cues from the Elm Architecture which clearly separates the concerns of Models, Views, and Actions. And finally, we'll take lessons learned from Redux and apply them back to RxJS.
+
+

--- a/_talks/functional-programming-in-ember-the-emberredux-origin-story.md
+++ b/_talks/functional-programming-in-ember-the-emberredux-origin-story.md
@@ -1,0 +1,14 @@
+---
+title: Functional Programming in Ember? The Ember-Redux Origin Story
+date: May 11, 2016
+tags:
+  - Ember
+  - Functional Programming
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+I've become more interested in functional programming this year but didn't know how exactly I could bring that experience to ember. After a few hours cargo culting the react-redux api it was clear I had something that would forever change the way I wrote ember web applications. Join me for a live coding demo where I bring the mythical "functional core, imperative shell" concept to reality!
+

--- a/_talks/functional-reactive-programming-in-javascript-with-rxjs.md
+++ b/_talks/functional-reactive-programming-in-javascript-with-rxjs.md
@@ -1,0 +1,16 @@
+---
+title: Functional Reactive Programming in JavaScript with RxJS
+date: May 12, 2015
+tags:
+  - RxJS
+  - Functional Proramming
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+
+What is functional programming? What is reactive programming? How do those things come together to make application with JavaScript?
+
+RxJS is a library that helps you manage asynchronous programming using observable streams. Observable steam? It's like a collection of events over time or like a series of promises. It is a powerful tool for managing data, events, concurrency, etc...
+

--- a/_talks/future-proof-your-javascript-with-babel-.md
+++ b/_talks/future-proof-your-javascript-with-babel-.md
@@ -1,0 +1,14 @@
+---
+title: Future proof your javascript with Babel
+date: April 14, 2015
+tags:
+  - Babel
+  - ES6
+speaker: Joel Taddei
+twitter: taddeimania
+---
+
+(formerly 6to5)
+
+Do you love reading about all of the cool features of ECMAScript 6 and want to start using them in production today? You might just be a build step away!  We'll explore the cool things you could be writing right NOW with Babel.  We'll also chat about Grunt integration.
+

--- a/_talks/github-and-the-open-source-ecosphere.md
+++ b/_talks/github-and-the-open-source-ecosphere.md
@@ -1,0 +1,12 @@
+---
+title: github and the open source ecosphere
+date: September 10, 2013
+tags: Git
+speaker: Chad Thompson
+twitter: chadothompson
+---
+
+
+
+If you've been attending user group meetings, or just had someone forward you a GitHub URL - you've seen some of the things that developers have been doing in the Open Source community. In this session, I'll talk about open source development, the GitHub ecosphere and how you can get involved. Along the way, we'll share some success stories (and not so successful stories) about getting involved in the community, how you can make positive contributions and what to expect when you start your own open source project.
+

--- a/_talks/going-async-with-promises-and-generators.md
+++ b/_talks/going-async-with-promises-and-generators.md
@@ -1,0 +1,11 @@
+---
+title: Going Async with Promises and Generators
+date: February 10, 2015
+tags: ES6
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+Writing asynchronous code can be tough and you can quickly find yourself in callback inception. But with <s>ES6</s> ES2015's promises and generators, going async is now a little easier. Learn how promises help manage your callbacks and how generators give you finer control on when thing execute.
+

--- a/_talks/handlebarsjs--minimal-templating-on-steroids.md
+++ b/_talks/handlebarsjs--minimal-templating-on-steroids.md
@@ -1,0 +1,11 @@
+---
+title: Handlebars.js - Minimal Templating on Steroids
+date: March 10, 2015
+tags: Templating
+speaker: Thomas Lindner
+---
+
+
+
+Handlebars lets you build semantic client side templates quickly and easily.
+

--- a/_talks/indexeddb-fundamentals.md
+++ b/_talks/indexeddb-fundamentals.md
@@ -1,0 +1,11 @@
+---
+title: IndexedDB Fundamentals
+date: February 11, 2014
+tags: IndexDB
+speaker: Nicholas Starke
+---
+
+
+
+For this presentation, we will focus primarily on client-side usage of IndexedDB; specifically, a brief technical overview, then lots of “live coding” to show the syntax for CRUD operations on the client side as well as demonstrate the transactional system that is fundamental to IndexedDB.  We’ll look at the tools available in Chrome to help debug / analyze / manipulate data, and then finish up by a brief discussion of real-world use cases, as well as limitations of IndexedDB.
+

--- a/_talks/installing-and-setting-up-nodejs-and-npm---a-beginner-friendly-guide.md
+++ b/_talks/installing-and-setting-up-nodejs-and-npm---a-beginner-friendly-guide.md
@@ -1,0 +1,14 @@
+---
+title: Installing and Setting Up Node.js and npm -  A Beginner Friendly Guide
+date: February 9, 2016
+tags:
+  - Node
+  - npm
+speaker: Jeff Donovan
+twitter: _Jeff_D_
+---
+
+
+
+Node.js has rapidly become one of the most popular web frameworks. Its package manager, npm, has become the largest software module epository in the world with over 200,000 packages. With so many packages, the quality and compatibility issues can vary widely. Also, with so many new and better packages coming out, the most widely used packages may not necessarily be the best.
+

--- a/_talks/intro-to-absurdjs.md
+++ b/_talks/intro-to-absurdjs.md
@@ -1,0 +1,14 @@
+---
+title: Intro to Absurd.js
+date: September 9, 2014
+tags: Absurd
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+
+Absurd.js started out as a JavaScript based CSS preprocessor. It has now grown into a framework with HTML preprocessing, dependency injection, and components.
+
+In this talk we will go through the basic of building an application using Absurd.js.
+

--- a/_talks/intro-to-angularjs.md
+++ b/_talks/intro-to-angularjs.md
@@ -1,0 +1,11 @@
+---
+title: Intro to AngularJS
+date: January 13, 2015
+tags: Angular
+speaker: Jessa Sparks
+twitter: jessasparks
+---
+
+
+Tired of hearing about Ember? We finally have a talk about Angular at DSMJS! Learn the basics of Angular and how it can help you quickly develop JavaScript apps.
+

--- a/_talks/intro-to-es6.md
+++ b/_talks/intro-to-es6.md
@@ -1,0 +1,13 @@
+---
+title: Intro To ES6
+date: November 12, 2014
+tags: ES6
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+Sometimes with JavaScript you have to write some funky code and we all just accept it, because that's the way it is. Want to loop over the `arguments` passed into a function? Better use `Array.protototype.slice` on that bad boy first. Trying to do inheritance? Good luck.
+
+With the next generation of the language, some of these common problems become very easy. In this talk, we'll go over some of the new features of JavaScript and how to start using them today.
+

--- a/_talks/intro-to-grunt---stop-doing-things-manually.md
+++ b/_talks/intro-to-grunt---stop-doing-things-manually.md
@@ -1,0 +1,11 @@
+---
+title: Intro to Grunt -  Stop doing things manually
+date: September 10, 2013
+tags: Grunt
+speaker: Chuck Rolek
+twitter: crolek
+---
+
+
+
+Grunt is a Javascript Task Runner. If you've never heard of Grunt then this presentation is for you. Grunt can help you automatically compile Less/Coffeescript, compile templates, aggregate/minify files, and much more . Don't worry though, you don't have to run Grunt every time you want it to do something. I'll show you the Grunt Watch feature, so you can code faster.

--- a/_talks/intro-to-gulp.md
+++ b/_talks/intro-to-gulp.md
@@ -1,0 +1,12 @@
+---
+title: Intro to gulp
+date: March 11, 2014
+tags:
+speaker: Brandon Williams
+twitter: williamsbdev
+---
+
+
+
+Here is a gentle introduction to Gulp and a brief comparison of Gulp and Grunt. A brief explanation of why all web developers should be using at least one of these two tools for all their projects.
+

--- a/_talks/intro-to-web-components.md
+++ b/_talks/intro-to-web-components.md
@@ -1,0 +1,12 @@
+---
+title: Intro to Web Components
+date: April 8, 2014
+tags:
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+
+Web Components might not be ready for use yet, but they are ramping up to take over the world of front end development. In this talk, I'll go over the 5 building blocks that make up web components and try to tie them back to the technologies you are probably using today.
+

--- a/_talks/introduction-to-clojurescript.md
+++ b/_talks/introduction-to-clojurescript.md
@@ -1,0 +1,25 @@
+---
+title: Introduction to ClojureScript
+date: October 8, 2013
+tags:
+speaker: David W. Body
+twitter: david_body
+---
+
+
+
+ClojureScript compiles [Clojure](http://clojure.org/) to optimized JavaScript. Specifically, the compiler emits JavaScript compatible with the advanced compilation mode of [Google Closure](http://code.google.com/closure/).
+
+We'll start with an introduction to [Clojure](http://clojure.org/), assuming no prior knowledge of the language. Clojure is a dynamic, general purpose programming language (actually a Lisp dialect) that features a rich set of immutable data structures, lazy sequences, first-class functions, macros, and other features.
+
+Then we'll look at ClojureScript, which compiles Clojure code to optimized JavaScript that can be used on a web page or run in another JavaScript environment such as [Node.js](http://nodejs.org/).
+
+We'll cover
+
+* Setting up a simple ClojureScript project
+* ClojureScript build process, including compilation modes
+* JavaScript Interop
+
+If time permits, we'll look at the new [core.async](https://github.com/clojure/core.async) library that provides a solution to "callback hell."
+
+

--- a/_talks/is-your-grunt-file-maintainable.md
+++ b/_talks/is-your-grunt-file-maintainable.md
@@ -1,0 +1,12 @@
+---
+title: Is your Grunt file maintainable?
+date: November 12, 2013
+tags: Grunt
+speaker: Brandon Williams
+twitter: williamsb86
+---
+
+
+
+This lightning talk will present the way that Grunt files used to be written and show a couple of Node modules (load-grunt-config and load-grunt-tasks) that allow your Gruntfile to be minimal. This is the JavaScript (or CoffeeScript) of the future.
+

--- a/_talks/it-hurtsso-good---.md
+++ b/_talks/it-hurtsso-good---.md
@@ -1,0 +1,14 @@
+---
+title: It hurts....so Good
+date: November 10, 2015
+tags: ES6
+speaker: Caleb Boyd & Dusty Greif
+---
+
+)
+
+While the bleeding-edge can be painful, there is an incredible amount of power to be found
+in future versions of javascript.  We will be showing off some of the techniques and tools
+that TelePharm has been using to increase our productivity (We'd be going much faster if it wasn't for the new guy.) and code clarity as we build the next version of our application. Specifically, we will be
+demonstrating some useful patterns that have been previously unavailable in the javascript ecosystem.
+

--- a/_talks/javascript-cryptography.md
+++ b/_talks/javascript-cryptography.md
@@ -1,0 +1,15 @@
+---
+title: Javascript Cryptography
+date: November 12, 2014
+tags: Cryotograpy
+speaker: Nick Starke
+twitter: nstarke
+---
+
+
+Advances in JavaScript cryptography have resulted in several libraries made available that can perform client side encryption.  We’ll look at two of the most common, SJCL and CryptoJS, along with the WebCrypto API that the W3C is currently drafting.  Finally, we’ll look at the practical applications and pitfalls of using client side encryption and discuss real world use cases.
+
+[Nick Starke](https://twitter.com/nstarke) is an information security developer with an interest in all things crypto.
+
+
+

--- a/_talks/javascript-game-development-.md
+++ b/_talks/javascript-game-development-.md
@@ -1,0 +1,22 @@
+---
+title: JavaScript Game Development
+date: May 14, 2013
+tags: Impact
+speaker: Joel Taddei
+twitter: taddeimania
+---
+
+(intermediate ImpactJS)
+
+Joel will be giving a Part II version of his [DSM Webgeeks lunch presentation](http://www.dsmwebgeeks.com/2013/04/javascript-game-development-%E2%80%93-lunch-meeting-wed-april-17th/)
+(April 17th) on Javascript Game Development and will build on some of the basic
+concepts he demonstrated.  He will be modeling much of the talk after the Introducing
+HTML5 Game Development book by Jesse Freeman and will introduce concepts such as:
+
+- Gravity / Friction
+- Collision Objects
+- Player vs. Enemy entities
+
+If there is time and interest he will also demonstrate how to package an ImpactJS
+game to run native on an iOS device - while not writing ANY Objective-C.
+

--- a/_talks/javascript-prototypes.md
+++ b/_talks/javascript-prototypes.md
@@ -1,0 +1,12 @@
+---
+title: JavaScript Prototypes
+date: June 10, 2014
+tags: Prototype
+speaker: Matthew J. Morrison
+twitter: mattjmorrison
+---
+
+
+
+Have you ever come across JavaScript source that contained some weird thing called prototype? Did you think "Oh crap, I'm in too deep!" and just move onto something else? Prototypes in JavaScript are quite a bit different than most other popular languages. I will talk about what it is and demonstrate how to use it.
+

--- a/_talks/knockoutjs.md
+++ b/_talks/knockoutjs.md
@@ -1,0 +1,12 @@
+---
+title: KnockoutJS
+date: May 13, 2014
+tags: Knockout
+speaker: Jon von Willern
+twitter: vongillern
+---
+
+
+
+Love MVVM? Hate storing state in the DOM and complex DOM manipulation? Don't want to deal with Angular's routes, modules and service factory factories? Want excellent browser compatibility? Knockout JS just may be what you're looking for. Swing by this session and let Knockout knock your socks off.
+

--- a/_talks/lets-talk-about-real-time-web-applications.md
+++ b/_talks/lets-talk-about-real-time-web-applications.md
@@ -1,0 +1,16 @@
+---
+title: Lets talk about real time web applications!
+date: March 11, 2014
+tags: Web Sockets
+speaker: Joel Taddei
+twitter: taddeimania
+---
+
+
+
+In this 25 minute run down we will delve into the socket.io library and how you can get up and running with it in minutes.  The server / client relationship will be demystified, we will squash the optimistic rendering paradigm, and chances are you will be ready to implement your own chat room protocol that's on par with IRC.
+
+Okay so maybe that may be a bit ambitious, but i've been playing with socket.io a lot lately and i'd like to share my experiences with my favorite community in Des Moines!
+
+Who knows, you may even get some JS related stickers just for showing up!
+

--- a/_talks/make-money-freelancing.md
+++ b/_talks/make-money-freelancing.md
@@ -1,0 +1,10 @@
+---
+title: Make money freelancing
+date: April 12, 2016
+tags: Freelancing
+speaker: Matthew Nuzum
+twitter: newz2000
+---
+
+
+Over the last 15 years I've taken on several freelance projects. Some of these worked great and some were disasters. I'll share the tips for finding interesting challenges and ensuring that projects have a high chance of success. I'll cover how to charge, how much to charge, and ensuring that expectations are clear and met.

--- a/_talks/outsidein-test-driven-development.md
+++ b/_talks/outsidein-test-driven-development.md
@@ -1,0 +1,12 @@
+---
+title: Outside-In Test Driven Development
+date: October 13, 2015
+tags: TDD
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Modern day single page apps incorporate acceptance tests, integration tests, and unit tests but when do write them and how do you choose what type to write and why? Join me for a 45 minute live coding session where I show a technique that's helped me build javascript applications sustainably from the outside in.
+

--- a/_talks/phaserjs.md
+++ b/_talks/phaserjs.md
@@ -1,0 +1,13 @@
+---
+title: Phaser.js
+date: February 10, 2015
+tags: Phaser
+speaker: David Moritz
+---
+
+
+Phaser is a gaming engine developed entirely in JavaScript. Phaser does the work of calculating gravity, collision-detection, level advancement, sprite animation and much more.
+
+Come learn the basics of Phaser and how to make a quick, web-based game.
+
+

--- a/_talks/react--routing--lazy-loading-and-es6.md
+++ b/_talks/react--routing--lazy-loading-and-es6.md
@@ -1,0 +1,14 @@
+---
+title: React / Routing / Lazy Loading and ES6
+date: August 12, 2014
+tags:
+  - React
+  - ES6
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+On the surface web components seem like a great way to get started, but as your JavaScript application grows how do you compose them together in a maintainable way? How can you add client side routing to keep your application from breaking the web? What about lazy loading entire modules inside your application on the fly? Join me for a live coding session where I show all the above incrementally by building out a JavaScript application with react and the react-router!
+

--- a/_talks/react-render-server-or-client.md
+++ b/_talks/react-render-server-or-client.md
@@ -1,0 +1,9 @@
+---
+title: React.render(ClientOrServer, document.querySelector(‘.you-decide’));
+date: August 11, 2015
+tags: React
+speaker: Jason Bradley
+twitter: jason_bradley
+---
+
+It is hard to read any JavaScript news without mention of ReactJS. This talk is an introduction to React and why it's awesome. We will talk about the Virtual DOM, the data flow, and where it fits in the JavaScript stack. I will share some of my experiences with React both best practices and future plans.

--- a/_talks/redux---the-beginner-friendly-introduction.md
+++ b/_talks/redux---the-beginner-friendly-introduction.md
@@ -1,0 +1,11 @@
+---
+title: Redux -  the beginner friendly introduction
+date: January 12, 2016
+tags: Redux
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Does the word flux make you anxious? Does adding reducers, actions and a store to your JavaScript app sound like unnecessary complexity? Join me for a truly beginner friendly discussion about redux and why predictable state changes are the way forward!

--- a/_talks/refactor-like-a-scientist.md
+++ b/_talks/refactor-like-a-scientist.md
@@ -1,0 +1,15 @@
+---
+title: Refactor Like a Scientist
+date: September 13, 2016
+tags: Scientist
+speaker: Fred Galoso
+twitter: wayoutmind
+---
+
+
+
+Tests are a good baseline for defining the behavior of a program. Though, on complicated programs, are tests enough?
+
+[Scientist](https://github.com/trello/scientist) is a [Node.js](https://nodejs.org/en/) library for creating and running experiments between old and new pieces of code. Scientist makes it easy to refactor critical code paths with confidence. It safely exposes refactorings to actual production interactions and measures potential mismatches. Part experience report, refactoring discussion, and workshop, this talk will also explore safe refactoring techniques at companies like Trello and [GitHub](https://github.com/).
+
+

--- a/_talks/responsible-responsive-web-design.md
+++ b/_talks/responsible-responsive-web-design.md
@@ -1,0 +1,12 @@
+---
+title: Responsible Responsive Web Design
+date: June 9, 2015
+tags: Responsive Web Design
+speaker: Matt Busche
+twitter: mrbusche
+---
+
+
+
+Come learn what Responsive Design is and how to build a website using it. We'll also cover how to design a website responsibly - How you can deliver a consisten user experience to users on small and large screen devices and how to decrease your website's page size quickly and effectively to ensure your website loads fast even on slow internet connections.
+

--- a/_talks/responsive-tables-with-tablesaw.md
+++ b/_talks/responsive-tables-with-tablesaw.md
@@ -1,0 +1,12 @@
+---
+title: Responsive Tables with Tablesaw
+date: March 10, 2015
+tags:
+  - Responsive Web Design
+  - Tablesaw
+speaker: Korina Borowycz
+---
+
+
+
+Tablesaw is a collection of plugins for responsive tables. It does all the heavy lifting for a number of scenarios, it lets you apply rules to determine the presentation layout and priority of columns.  It also gives a wide array of options to users so they can view data how they would like to. With at least 5 different main options you can add into tables it gives you a wide variety of options with minimal development time.

--- a/_talks/robotics-with-javascript.md
+++ b/_talks/robotics-with-javascript.md
@@ -1,0 +1,10 @@
+---
+title: Robotics with JavaScript
+date: August 9, 2016
+tags: Robotics
+speaker: Michael Parker
+---
+
+
+
+Learn how to leverage Node.JS on Raspberry Pi and Arduino microcontrollers to build small robots and IoT devices. Examples will include working with general purpose input/output, using servos and motors, communicating using radio transceivers, and interacting with LEDs and LCD screens.

--- a/_talks/testing-async-node-functions-with-mocha-and-jasmine-20.md
+++ b/_talks/testing-async-node-functions-with-mocha-and-jasmine-20.md
@@ -1,0 +1,12 @@
+---
+title: Testing async node functions with mocha and jasmine 2.0
+date: June 10, 2014
+tags: TDD
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Unit testing synchronous code in javascript is fairly straight forward, but what about async functions? Join me for a live coding session where I test drive a simple gulp task using mocha! I'll also show how to test basic async behavior with the latest jasmine framework.
+

--- a/_talks/the-future-a-story-about-the-vnext-developer-toolchain.md
+++ b/_talks/the-future-a-story-about-the-vnext-developer-toolchain.md
@@ -1,0 +1,15 @@
+---
+title: The future! A story about the vNext developer toolchain
+date: October 11, 2016
+tags: Redux
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+On large teams we spend a great deal of time providing accurate and concise instructions to reproduce a problem when QA finds an issue. What if instead we could export the state of the application and attach it as an artifact for the developer for further debugging and verification?
+
+In this talk I'll discover a bug and show a QA/Dev workflow that I believe is the future of QA and Dev collaboration.
+
+

--- a/_talks/umm-i-created-a-presentation-with-sailjs.md
+++ b/_talks/umm-i-created-a-presentation-with-sailjs.md
@@ -1,0 +1,16 @@
+---
+title: Umm, I created a presentation with Sailjs?
+date: June 9, 2015
+tags: Sails
+speaker: Chuck Rolek
+twitter: crolek
+---
+
+
+
+Sailsjs is great for creating awesome backend applications. Its very quick to stand up an endpoint and fly forward. However, what if you wanted to use it as your presentation platform (like Revealjs)? This talk is focused around the flexibility that Sailjs provides it’s users.
+
+**Chuck Rolek**
+[@crolek](https://twitter.com/crolek)
+Fueled by silliness and coffee Chuck tries to create efficiency in everything he and others do. His specialties are Front-end development, architecture, continuous integration, and bringing much needed innovation to enterprises. He absolutely love technology, and spends a vast majority of his time learning about it or teaching it.
+

--- a/_talks/unit-and-integration-testing---better-together.md
+++ b/_talks/unit-and-integration-testing---better-together.md
@@ -1,0 +1,12 @@
+---
+title: Unit and Integration testing -  better together
+date: April 8, 2014
+tags: TDD
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+The biggest challenge adopting test driven development is knowing when to write a unit test and/or integration test as you write new features or fix production bugs. During this short talk I'll test drive adding a new feature using both unit and integration tests. The focus of this talk is the inner dialog I have along the way (asking myself when each type of test is valuable and why).
+

--- a/_talks/unit-testing-methodsmodules-in-isolation-with-qunit.md
+++ b/_talks/unit-testing-methodsmodules-in-isolation-with-qunit.md
@@ -1,0 +1,13 @@
+---
+title: Unit testing methods/modules in isolation with QUnit
+date: February 11th 2014
+tags:
+  - TDD
+  - QUnit
+speaker: Jarrod Taylor
+---
+
+
+
+Have you ever wanted to run a single unit test while you do test driven development in javascript? Are you using Karma and QUnit? During this talk I'll show how to add a plugin to the default karma test runner that lets you get fast feedback as you build your application test-first. This talk will be a basic intro to the plugin/karma/qunit and should be under 15 minutes.
+

--- a/_talks/universal-javascript-rendering-react-on-ther-server-and-client.md
+++ b/_talks/universal-javascript-rendering-react-on-ther-server-and-client.md
@@ -1,0 +1,9 @@
+---
+title: Universal Javascript - Rendering React on the server and client
+date: September 8, 2015
+tags: React
+speaker: Logan Keenan
+twitter: dlogankeenan
+---
+
+Is your SPA was easily indexable, [Fast](https://blog.twitter.com/2012/improving-performance-on-twittercom), maintainable?  I will show how to server side render any initial request into a SPA with [hapi](http://hapijs.com/) and [React](http://facebook.github.io/react/), and then client side render any following requests.  Write your views in React once and don't worry where they render.

--- a/_talks/using-backbone-to-visualize-music.md
+++ b/_talks/using-backbone-to-visualize-music.md
@@ -1,0 +1,16 @@
+---
+title: Using Backbone to Visualize Music
+date: June 13, 2013
+tags: Backbone
+speaker: Jack Viers
+twitter: jackviers
+---
+
+
+
+For this talk, I'm thinking Harder, Better, Faster, Stronger -- using
+Backbone to visualize music. I'll demonstrate how to use routers,
+models, and views to do some cool stuff -- like making a media player
+that can pick up where you left off, visualize the music to which you
+are listening, and manage a music library -- ya know, non-crud stuff.
+

--- a/_talks/using-es6-modules-today.md
+++ b/_talks/using-es6-modules-today.md
@@ -1,0 +1,12 @@
+---
+title: Using ES6 modules today
+date: May 13, 2014
+tags: ES6
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Do you want to use the next generation of javascript modules today? Join me for a live coding session where I show how to write es6 modules and transpile them to AMD. Specifically I'll be showing off the es6-module-transpiler. If we have time I'll also show a bower demo where you can install and import modules on demand without having to worry about order dependent scripts (even for scripts with nested dependencies).
+

--- a/_talks/vagrant.md
+++ b/_talks/vagrant.md
@@ -1,0 +1,11 @@
+---
+title: Vagrant
+date: April 14, 2015
+tags: Vagrant
+speaker: Shawn Sparks
+twitter: marshmellow1328
+---
+
+
+Ever inherit an app only to spend hours or days trying to get it to run locally? Tried running apps locally on one OS when production servers use a different OS? Tried something new and completely messed up your workstation? Wondered if there’s a better way? Vagrant is a tool for solving these challenges. It relies on virtualization and automation tools to quickly spin up local development environments. Easily blow away and recreate environments after screwing them up. Generally make life easier for devs working with the app, allow them to focus on adding new features, and not wasting time getting their local environment setup.
+

--- a/_talks/vuejs.md
+++ b/_talks/vuejs.md
@@ -1,0 +1,12 @@
+---
+title: VueJS
+date: January 10, 2017
+tags: Vue
+speaker: Paul Rowe
+---
+
+
+
+VueJS, databinding for the rest of us
+
+Paul Rowe is a consultant at Source Allies. With nearly 10 years of software development experience, Paul enjoys dabbling in new technologies and discussing different solutions to any technical problems. Most recently, Paul is leading architecture design and development in C# and Node.js on Azure.

--- a/_talks/what-is-this.md
+++ b/_talks/what-is-this.md
@@ -1,0 +1,11 @@
+---
+title: What is "this"
+date: July 11, 2013
+tags:
+speaker: Matthew J. Morrizon
+twitter: mattjmorrison
+---
+
+
+Part of JavaScript’s charm and elegance stems from the fact that it works quite a bit differently than most other languages. The “this” keyword is one of the parts of JavaScript that seems to behave perhaps a bit differently than what might be expected. In addition to the “this” keyword, I will discuss execution contexts, the “new” operator, the call, apply and bind functions, and strict mode.
+

--- a/_talks/why-single-page-apps-anyway.md
+++ b/_talks/why-single-page-apps-anyway.md
@@ -1,0 +1,11 @@
+---
+title: why single page apps anyway?
+date: August 20, 2013
+tags: SPA
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Ever wonder what all the hype around single page apps is about? Join us for a beginner friendly discussion about what makes building a single page app different from traditional web development and why you would choose one over the other.

--- a/_talks/working-with-files-in-the-browser.md
+++ b/_talks/working-with-files-in-the-browser.md
@@ -1,0 +1,12 @@
+---
+title: Working with files in the browser
+date: October 8, 2013
+tags: File API
+speaker: Eric Ponto
+twitter: ericponto
+---
+
+
+
+Reading and manipulating files has traditionally been a job for the server. But with new JavaScript APIs, it opens a world of possibilities to work with files in the browser. Get a quick introduction to the File API, the FileReader object, and see a couple of cool things you can do with them.
+

--- a/_talks/writing-javascript-like-a-grownup.md
+++ b/_talks/writing-javascript-like-a-grownup.md
@@ -1,0 +1,17 @@
+---
+title: Writing JavaScript like a grown-up
+date: May 14, 2013
+tags:
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Are you producing write-once / read-never javascript? Do you want to
+develop something you can reason about but just don't know where to start?
+Join us for a 30 minute beginner friendly discussion about how I was writing
+javascript a year ago and what I did to improve the quality of my client side
+code!
+
+

--- a/_talks/writing-my-first-nontrivial-single-page-app.md
+++ b/_talks/writing-my-first-nontrivial-single-page-app.md
@@ -1,0 +1,28 @@
+---
+title: Writing my first non-trivial single page app
+date: November 12, 2013
+tags: SPA
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+Anyone can hype their favorite javascript framework but what happens when you need to build something bigger than a todo app? I decided to find out for myself a few months back when I started writing my first ambitious javascript application.
+
+During this talk I'll cover
+
+* What is so great about the url?
+* So what happens when I click refresh?
+* Prevent data loss when the user clicks the back button
+* Do you need objects with rich relationships?
+* How to bootstrap your application at runtime
+* Sharing state between views/routes
+* What about catastrophic javascript errors?
+* What does $.ajax error handling look like?
+* Where do you handle application wide navigation?
+* How does jQuery fit into the picture today?
+* What build tool did I use and how did I deploy with it?
+* When did I find unit tests helpful? When integration tests?
+* Transactions -do we need them on the client?
+

--- a/_talks/writing-tests-for-javascript-with-qunitsinon-and-karma.md
+++ b/_talks/writing-tests-for-javascript-with-qunitsinon-and-karma.md
@@ -1,0 +1,13 @@
+---
+title: Writing tests for javascript with QUnit/Sinon and Karma
+date: July 11, 2013
+tags: TDD
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+So you want to write a single page app with your javascript framework of choice, but how do you test these rich web applications? Join me for a discussion about my frontend testing journey and a hands on demo of QUnit/Sinon and the Karma test runner. Some basic understanding of unit testing is recommended but not required.
+
+

--- a/_talks/writing-your-first-react-component.md
+++ b/_talks/writing-your-first-react-component.md
@@ -1,0 +1,13 @@
+---
+title: Writing your first react component
+date: July 8, 2014
+tags: React
+speaker: Toran Billups
+twitter: toranb
+---
+
+
+
+React is a JavaScript library for building user interfaces. It's declarative, efficient, and extremely flexible. But what does all this mean exactly? Join me for a live coding session where I show off a few of the basic concepts required to write your first react component!
+
+

--- a/archive/index.html
+++ b/archive/index.html
@@ -8,6 +8,12 @@ title: Past Meetings
 {% for post in paginator.posts %}
 	<div class="meeting">
 		<h4 class="meeting-title"><a href="{{ post.url }}">{{ post.date  | date: "%B %d, %Y" }}</a></h4>
+
+		{% capture pagedate %}{{ post.date | date: '%B %-d, %Y'}}{% endcapture %}
+		{% assign dateTalks = site.talks | where:"date",pagedate %}
+		{% for talk in dateTalks %}
+				<h5 class="talk-card">{{ talk.title}}</h5>
+		{% endfor %}
 	</div>
 {% endfor %}
 

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -11,5 +11,6 @@
 @import "footer";
 @import "paginator";
 @import "bottom-nav";
+@import "talk";
 
 @import "utils";

--- a/index.html
+++ b/index.html
@@ -6,7 +6,21 @@ title: dsmJS
 <h2 itemprop="startDate" content="{{ site.posts.first.date | date: "%Y-%m-%d" }}">{{ site.posts.first.date | date: "%B %d, %Y" }}</h2>
 <p>{{ site.posts.first.time }} @ {{ site.posts.first.location }}</p>
 
-{{ site.posts.first.content }}
+
+{% capture pagedate %}{{ site.posts.first.date | date: '%B %-d, %Y'}}{% endcapture %}
+{% assign dateTalks = site.talks | where:"date",pagedate %}
+{% for talk in dateTalks %}
+	<h3 class="talk-title">{{ talk.title}} </h3>
+	<h4 class="talk-speaker">
+		{{ talk.speaker }}
+		{% if talk.twitter %}
+			<small><a href="https://twitter.com/{{ talk.twitter }}">@{{ talk.twitter }}</a></small>
+		{% endif %}
+	</h4>
+
+	{{ talk.content }}
+{% endfor %}
+
 
 {% if site.posts.first.tiklyWidgetID.size > 0 %}
 <div class="tickly">


### PR DESCRIPTION
Kind of a big refactor of how meetings are structured. There is now a _talks directory that holds the talks independently of the meeting. They are related by their dates. This makes the past events better and will let us more easily add extra meta data to talks (like links to the slides or git repo).